### PR TITLE
Perf: 변경 탈퇴한 회원에게는 알림 발송 안되게 수정

### DIFF
--- a/src/main/java/com/project/makecake/service/CommentService.java
+++ b/src/main/java/com/project/makecake/service/CommentService.java
@@ -70,7 +70,10 @@ public class CommentService {
         commentRepository.save(comment);
 
         // 댓글 작성자와 게시글 작성자가 다를 경우에만 댓글 알림 발송
-        if (!user.getUserId().equals(foundPost.getUser().getUserId())) {
+        if (
+                !user.getUserId().equals(foundPost.getUser().getUserId())
+                && foundPost.getUser().getRole()!=null
+        ) {
             addCommentNoti(foundPost,user);
         }
 

--- a/src/main/java/com/project/makecake/service/PostService.java
+++ b/src/main/java/com/project/makecake/service/PostService.java
@@ -3,6 +3,7 @@ package com.project.makecake.service;
 import com.project.makecake.dto.*;
 import com.project.makecake.enums.FolderName;
 import com.project.makecake.enums.NotiType;
+import com.project.makecake.enums.UserRoleEnum;
 import com.project.makecake.model.*;
 import com.project.makecake.repository.*;
 import com.project.makecake.security.UserDetailsImpl;
@@ -266,7 +267,10 @@ public class PostService {
             postLikeRepository.save(postLike);
 
             // 좋아요 누른 유저와 게시글 작성자가 다를 경우에만 좋아요 알림 발송
-            if (!user.getUserId().equals(foundPost.getUser().getUserId())) {
+            if (
+                    !user.getUserId().equals(foundPost.getUser().getUserId())
+                    && foundPost.getUser().getRole()!=null
+            ) {
                 addLikeNoti(foundPost, user);
             }
 


### PR DESCRIPTION
탈퇴한 회원의 글에 댓글을 달거나 좋아요를 눌렀을 때 좋아요, 댓글 알림이 생성되지 않도록 수정